### PR TITLE
Fix invalid order of fixtures due to filename

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -810,12 +810,25 @@ module.exports = {
 `;
 
     name = name.replace(' ', '_');
-    let filename = path.join(migrationsDir, revision + ((name != '') ? `-${name}` : '') + '.js');
+    let filename = path.join(migrationsDir, getCurrentYYYYMMDDHHmms() + '-' + revision + ((name != '') ? `-${name}` : '') + '.js');
 
     fs.writeFileSync(filename, template);
     
     return {filename, info};
 };
+
+const getCurrentYYYYMMDDHHmms = function () {
+  const date = new Date();
+  return [
+    date.getUTCFullYear(),
+    format(date.getUTCMonth() + 1),
+    format(date.getUTCDate()),
+    format(date.getUTCHours()),
+    format(date.getUTCMinutes()),
+    format(date.getUTCSeconds())
+  ].join('');
+}
+
 
 const executeMigration = function(queryInterface, filename, pos, cb)
 {

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -817,6 +817,10 @@ module.exports = {
     return {filename, info};
 };
 
+const format = function (i) {
+  return parseInt(i, 10) < 10 ? '0' + i : i;
+}; 
+
 const getCurrentYYYYMMDDHHmms = function () {
   const date = new Date();
   return [
@@ -827,7 +831,7 @@ const getCurrentYYYYMMDDHHmms = function () {
     format(date.getUTCMinutes()),
     format(date.getUTCSeconds())
   ].join('');
-}
+};
 
 
 const executeMigration = function(queryInterface, filename, pos, cb)


### PR DESCRIPTION
Uses date time based filename so migrations run in the correct order.