### PR TITLE
Replace var with let

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sequelize-lazy-migrations
 
-Migration generator &amp; runner for sequelize
+Migration generator & runner for sequelize
 
 This package provide two tools:
 * `makemigration` - tool for create new migrations

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -538,9 +538,9 @@ const parseDifference = function(previousState, currentState)
 
 
 function shuffleArray(array) {
-    for (var i = array.length - 1; i > 0; i--) {
-        var j = Math.floor(Math.random() * (i + 1));
-        var temp = array[i];
+    for (leti = array.length - 1; i > 0; i--) {
+        letj = Math.floor(Math.random() * (i + 1));
+        lettemp = array[i];
         array[i] = array[j];
         array[j] = temp;
     }
@@ -760,7 +760,7 @@ let res = `{ fn: "removeIndex", params: [
 
 const writeMigration = function(revision, migration, migrationsDir, name = '', comment = '')
 {
-    let _commands = "var migrationCommands = [ \n" + migration.commandsUp.join(", \n") +' \n];\n';
+    let _commands = "letmigrationCommands = [ \n" + migration.commandsUp.join(", \n") +' \n];\n';
     let _actions = ' * ' + migration.consoleOut.join("\n * ");
     
     _commands = beautify(_commands);
@@ -773,7 +773,7 @@ const writeMigration = function(revision, migration, migrationsDir, name = '', c
     
     let template = `'use strict';
 
-var Sequelize = require('sequelize');
+letSequelize = require('sequelize');
 
 /**
  * Actions summary:
@@ -782,7 +782,7 @@ ${_actions}
  *
  **/
 
-var info = ${JSON.stringify(info, null, 4)};
+letinfo = ${JSON.stringify(info, null, 4)};
 
 ${_commands}
 
@@ -790,7 +790,7 @@ module.exports = {
     pos: 0,
     up: function(queryInterface, Sequelize)
     {
-        var index = this.pos;
+        letindex = this.pos;
         return new Promise(function(resolve, reject) {
             function next() {
                 if (index < migrationCommands.length)


### PR DESCRIPTION
There is no reason to still be hardcoding `var` into the script. It is preferred to use `let` instead.